### PR TITLE
Remove content encoding and content length due to CDN response compression

### DIFF
--- a/frontend/app/api/proxy/[...path]/route.ts
+++ b/frontend/app/api/proxy/[...path]/route.ts
@@ -49,6 +49,8 @@ async function handler(
 
     const responseHeaders = new Headers(response.headers)
     responseHeaders.delete('transfer-encoding')
+    responseHeaders.delete('content-encoding')
+    responseHeaders.delete('content-length')
 
     // Resolve user session (server-side, no extra round-trip)
     const session = await getServerSession(authConfig)


### PR DESCRIPTION
… headers

Railway CDN (railway-hikari) compresses API responses and sets Content-Encoding: gzip. Node.js fetch auto-decompresses the body, but the header was forwarded as-is, causing browsers to receive plain JSON while expecting gzip → ERR_CONTENT_DECODING_FAILED.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved response handling by refining how upstream headers are processed, ensuring proper content delivery to the client.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->